### PR TITLE
Removed CDVWKWebViewEngine loadRequest override

### DIFF
--- a/src/ios/CDVWKWebViewEngine+CodePush.m
+++ b/src/ios/CDVWKWebViewEngine+CodePush.m
@@ -1,6 +1,6 @@
 #if defined(__has_include)
 #if __has_include("CDVWKWebViewEngine.h")
-#if !(TARGET_OS_SIMULATOR)
+#if NO
 
 #import "CDVWKWebViewEngine.h"
 


### PR DESCRIPTION
This disables this piece of code which overrides the loadRequest method in the WKWebviewEngine.
The loadRequest in the WKWebviewEngine, rewrites the urls from file:/// to http://localhost:8080/ , without these rewrites, access to local files from the webview are blocked.